### PR TITLE
feat: connect category and products

### DIFF
--- a/gatsby-source-chec/gatsby-node.js
+++ b/gatsby-source-chec/gatsby-node.js
@@ -1,1 +1,2 @@
 exports.sourceNodes = require('./gatsby/node/sourceNodes');
+exports.createSchemaCustomization = require('./gatsby/node/createSchemaCustomization');

--- a/gatsby-source-chec/gatsby/node/createSchemaCustomization.js
+++ b/gatsby-source-chec/gatsby/node/createSchemaCustomization.js
@@ -1,0 +1,13 @@
+const createSchemaCustomization = ({ actions: { createTypes } }) => {
+  createTypes(`
+    type ChecProduct implements Node {
+      categories: [ChecCategory] @link
+    }
+
+    type ChecCategory implements Node {
+      products: [ChecProduct] @link
+    }
+  `);
+};
+
+module.exports = createSchemaCustomization;

--- a/gatsby-source-chec/gatsby/node/sourceNodes.js
+++ b/gatsby-source-chec/gatsby/node/sourceNodes.js
@@ -77,9 +77,11 @@ const sourceNodes = async (
   });
 
   products.forEach(({ categories, ...product }) => {
+    const categoryIds = categories.map(({ id }) => id);
+
     createNode({
       ...product,
-      categories: categories.map(({ id }) => id),
+      categories: categoryIds,
       internal: {
         type: `ChecProduct`,
         content: JSON.stringify(product),

--- a/gatsby-source-chec/gatsby/node/sourceNodes.js
+++ b/gatsby-source-chec/gatsby/node/sourceNodes.js
@@ -54,20 +54,32 @@ const sourceNodes = async (
     },
   });
 
-  categories.forEach((category) =>
+  categories.forEach((category) => {
+    const productIds = products.reduce((ids, product) => {
+      const matchingCategory = product.categories.find(
+        (cat) => cat.id === category.id
+      );
+
+      if (!matchingCategory) return ids;
+
+      return [...ids, product.id];
+    }, []);
+
     createNode({
       ...category,
+      products: productIds,
       internal: {
         type: `ChecCategory`,
         content: JSON.stringify(category),
         contentDigest: createContentDigest(category),
       },
-    })
-  );
+    });
+  });
 
-  products.forEach((product) => {
+  products.forEach(({ categories, ...product }) => {
     createNode({
       ...product,
+      categories: categories.map(({ id }) => id),
       internal: {
         type: `ChecProduct`,
         content: JSON.stringify(product),


### PR DESCRIPTION
This PR enables queries such as:

```graphql
{
  allChecProduct {
    nodes {
      name
      categories {
        name
      }
    }
  }
}
```

and

```graphql
{
  allChecCategory {
    nodes {
      id
      products {
        name
        internal {
          type
        }
        id
      }
    }
  }
}
```