### PR TITLE
chore: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "automerge": true,
   "extends": ["config:base", "schedule:weekly"],
+  "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "major": {
     "automerge": false
-  }
+  },
+  "semanticCommits": true
 }


### PR DESCRIPTION
Ignore PRs with `chore` to stop unnecessary publishes to NPM.